### PR TITLE
note about python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Privacy-focused, command-line note-taking app that uses Locaal's on-device AI SD
 
 ## Prerequisites
 
-- Python 3.11 or higher
+- Python 3.11 or 3.12 (`simpler-whisper` requires doesn't support 3.13 yet)
 - Git
 
 ## Installation


### PR DESCRIPTION
Using `3.13` I just got:
```
ERROR: Ignored the following versions that require a different python version: 1.21.2 Requires-Python >=3.7,<3.11; 1.21.3 Requires-Python >=3.7,<3.11; 1.21.4 Requires-Python >=3.7,<3.11; 1.21.5 Requires-Python >=3.7,<3.11; 1.21.6 Requires-Python >=3.7,<3.11; 1.26.0 Requires-Python <3.13,>=3.9; 1.26.1 Requires-Python <3.13,>=3.9; 4.10 Requires-Python <3.11,>=3.6; 4.6 Requires-Python <3.11,>=3.6; 4.7 Requires-Python <3.11,>=3.6; 4.8 Requires-Python <3.11,>=3.6; 4.9 Requires-Python <3.11,>=3.6; 5.0 Requires-Python <3.11,>=3.7; 5.0.1 Requires-Python <3.11,>=3.7; 5.1 Requires-Python <3.11,>=3.7; 5.10.0 Requires-Python <3.12,>=3.7; 5.10.1 Requires-Python <3.12,>=3.7; 5.11.0 Requires-Python <3.12,>=3.7; 5.12.0 Requires-Python <3.12,>=3.7; 5.13.0 Requires-Python <3.13,>=3.7; 5.13.1 Requires-Python <3.13,>=3.7; 5.13.2 Requires-Python <3.13,>=3.7; 5.2 Requires-Python <3.11,>=3.7; 5.3 Requires-Python <3.11,>=3.7; 5.4 Requires-Python <3.11,>=3.7; 5.4.1 Requires-Python <3.11,>=3.7; 5.5 Requires-Python <3.12,>=3.7; 5.6 Requires-Python <3.12,>=3.7; 5.6.1 Requires-Python <3.12,>=3.7; 5.6.2 Requires-Python <3.12,>=3.7; 5.7.0 Requires-Python <3.12,>=3.7; 5.8.0 Requires-Python <3.12,>=3.7; 5.9.0 Requires-Python <3.12,>=3.7; 6.0.0 Requires-Python <3.13,>=3.8; 6.1.0 Requires-Python <3.13,>=3.8; 6.2.0 Requires-Python <3.13,>=3.8; 6.3.0 Requires-Python <3.13,>=3.8; 6.4.0 Requires-Python <3.13,>=3.8; 6.5.0 Requires-Python <3.13,>=3.8; 6.6.0 Requires-Python <3.13,>=3.8; 6.7.0 Requires-Python <3.13,>=3.8; 6.8.0 Requires-Python <3.13,>=3.8; 6.9.0 Requires-Python <3.13,>=3.8
ERROR: Could not find a version that satisfies the requirement simpler-whisper (from versions: none)
ERROR: No matching distribution found for simpler-whisper
```